### PR TITLE
The namespace-uri is now resolved explicitly before an attribute with a ...

### DIFF
--- a/src/main/clojure/clojure/data/xml.clj
+++ b/src/main/clojure/clojure/data/xml.clj
@@ -27,7 +27,11 @@
 (defn write-attributes [attrs ^javax.xml.stream.XMLStreamWriter writer]
   (doseq [[k v] attrs]
     (if (namespace k)
-      (.writeAttribute writer (str (namespace k)) (name k) (str v))
+      (let [prefix (str (namespace k))
+            namespace-uri (.getNamespaceURI
+                           (.getNamespaceContext writer)
+                           prefix)]
+        (.writeAttribute writer prefix namespace-uri (name k) (str v)))
       (.writeAttribute writer (name k) (str v)))))
 
 (defn write-namespaces [namespaces ^javax.xml.stream.XMLStreamWriter writer]

--- a/src/test/clojure/clojure/data/xml/test_emit.clj
+++ b/src/test/clojure/clojure/data/xml/test_emit.clj
@@ -109,11 +109,12 @@
     (is (= expect (.toString sw)))))
 
 (deftest test-namespace-emit
-  (let [expected (lazy-parse* "<clj:foo xmlns:clj='http://clojure.org'>
-                                <clj:bar>baz</clj:bar>
-                            </clj:foo>")]
-    (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><clj:foo xmlns:clj=\"http://clojure.org\"><clj:bar>baz</clj:bar></clj:foo>"
-           (emit-str (Element. :clj/foo
-                               {}
-                               [(element :clj/bar {} ["baz"] nil)]
-                               {"clj" "http://clojure.org"}))))))
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><clj:foo xmlns:clj=\"http://clojure.org\"><clj:bar clj:foobar=\"foobar\">baz</clj:bar></clj:foo>"
+         (emit-str (Element. :clj/foo
+                             {}
+                             [(element
+                               :clj/bar
+                               {:clj/foobar "foobar"}
+                               ["baz"]
+                               nil)]
+                             {"clj" "http://clojure.org"})))))


### PR DESCRIPTION
...namespace or rather prefix is written. The previous code passed the prefix as first argument to the writeAttribute(namespaceURI, localName, value) method of javax.xml.stream.XMLStreamWriter, which results in a "javax.xml.stream.XMLStreamException: Prefix cannot be null" exception.

I'm not sure if I used the correct way to resolve the namespace uri?

I don't have signed the CA aggreement yet, but I am going to sign it in the next couple of weeks.

Best regards

Max
