### PR TITLE
Disable support DTD

### DIFF
--- a/src/main/clojure/clojure/data/xml.clj
+++ b/src/main/clojure/clojure/data/xml.clj
@@ -77,7 +77,8 @@ for documentation on xml options. These are the defaults:
                        :coalescing true
                        :supporting-external-entities false
                        :location-info true
-                       :namespace-aware true}
+                       :namespace-aware true
+                       :support-dtd false}
                       opts)]
     (pull-seq (make-stream-reader props* source)
               props*


### PR DESCRIPTION
As defined by OWASP recommendations.
https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#xmlinputfactory-a-stax-parser.

Which should match Clojure XML defaults: https://github.com/clojure/clojure/blob/master/src/clj/clojure/xml.clj#L87